### PR TITLE
Replaces the default method to POST instead of GET

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -66,7 +66,7 @@ functions:
     events:
       - http:
           path: hello
-          method: get
+          method: post
 
 #    The following are a few example events you can configure
 #    NOTE: Please make sure to change your handler code to work with those events


### PR DESCRIPTION
This switches the function to accept requests via POST instead of GET.

This enables users to easily test failure scenarios by posting an invalid JSON body. 